### PR TITLE
fixed nuttx build test fail by adding new messages

### DIFF
--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -301,6 +301,10 @@ rtps:
     id: 134
   - msg: yaw_estimator_status
     id: 135
+  - msg: attitude_control_ext
+    id: 136
+  - msg: mixer_feedthrough
+    id: 137
   ########## multi topics: begin ##########
   - msg: actuator_controls_0
     id: 150


### PR DESCRIPTION
**Describe problem solved by this pull request**
Fixed failed nuttx test build.

**Describe your solution**
Added custom messages 'attitude_control_ext' and 'mixer_feedthrough' to 'uorb_rtps_message_ids.yaml' to generate the rtps files.
